### PR TITLE
Add new WebRTC patch for min level baseline profile

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -82,6 +82,7 @@ case $INPUT_STRING in
 		patch -b -p0 -d $WORK_DIR < $PATCHES_DIR/objc_video_encoder_factory_h.patch
 		patch -b -p0 -d $WORK_DIR < $PATCHES_DIR/video_decoder_factory_h.patch
 		patch -b -p0 -d $WORK_DIR < $PATCHES_DIR/video_encoder_factory_h.patch
+		patch -b -p0 -d $WORK_DIR < $PATCHES_DIR/minLevelBaselineProfile.patch
 		;;
 	*)
 		export PATH=$WORK_DIR/depot_tools:$PATH

--- a/patches/minLevelBaselineProfile.patch
+++ b/patches/minLevelBaselineProfile.patch
@@ -1,0 +1,11 @@
+--- webrtc/src/sdk/objc/components/video_codec/RTCH264ProfileLevelId.mm
++++ webrtc/src/sdk/objc/components/video_codec/RTCH264ProfileLevelId.mm
+@@ -28,7 +28,7 @@
+ 
+ NSString *const kRTCVideoCodecH264Name = @(cricket::kH264CodecName);
+ NSString *const kRTCLevel31ConstrainedHigh = @"640c1f";
+-NSString *const kRTCLevel31ConstrainedBaseline = @"42e01f";
++NSString *const kRTCLevel31ConstrainedBaseline = @"42e028";
+ NSString *const kRTCMaxSupportedH264ProfileLevelConstrainedHigh =
+     MaxSupportedProfileLevelConstrainedHigh();
+ NSString *const kRTCMaxSupportedH264ProfileLevelConstrainedBaseline =


### PR DESCRIPTION
Hello, 
This is a really simple patch of WebRTc to return 42e028 as default H264 profile level. 

We need this to allow 1080p support on latest iphones which are unknown from the m93 iphone devices switch case.  
We can make 42e028 the default as older iphones are known by the lib and will be assigned the correct profile, the default will be used by newer iphones (>iphone 12) not known by the lib.  