### PR TITLE
Added a new device load function to support customisation for peerConnection options 

### DIFF
--- a/Mediasoup/Device.swift
+++ b/Mediasoup/Device.swift
@@ -18,6 +18,12 @@ public class Device {
 			try device.load(with: routerRTPCapabilities)
 		}
 	}
+    
+    public func load(with routerRTPCapabilities: String, peerConnectionOptions:String, isRelayTransportPolicy:Bool = false) throws {
+        try convertMediasoupErrors {
+            try device.load(routerRTPCapabilities: routerRTPCapabilities, peerConnectionOptions: peerConnectionOptions, isRelayTransportPolicy: isRelayTransportPolicy)
+        }
+    }
 
 	public func rtpCapabilities() throws -> String {
 		try convertMediasoupErrors {

--- a/Mediasoup_Private/Device/DeviceWrapper.h
+++ b/Mediasoup_Private/Device/DeviceWrapper.h
@@ -18,6 +18,11 @@
 	__attribute__((swift_error(nonnull_error)))
 	NS_SWIFT_NAME (load(with:));
 
+- (void)loadWithRouterRTPCapabilities:(NSString *_Nonnull)routerRTPCapabilities peerConnectionOptions:(NSString *_Nonnull)peerConnectionOptions isRelayTransportPolicy:(BOOL)isRelayTransportPolicy
+    error:(out NSError *__autoreleasing  _Nullable *_Nullable)error
+    __attribute__((swift_error(nonnull_error)))
+    NS_SWIFT_NAME (load(routerRTPCapabilities:peerConnectionOptions:isRelayTransportPolicy:));
+
 - (NSString *_Nullable)sctpCapabilitiesWithError
 	:(out NSError *__autoreleasing _Nullable *_Nullable)error;
 


### PR DESCRIPTION
Currently the load function only supports the RCP capabilities so this PR contains one more load function which takes peerConnectionOptions (Ice server list) and a transport relay policy (Bool) same as Android lib. 