### PR TITLE
Fix: Improve MediasoupError description readability

### DIFF
--- a/Mediasoup/MediasoupClientErrorConverter.swift
+++ b/Mediasoup/MediasoupClientErrorConverter.swift
@@ -22,12 +22,12 @@ internal func convertMediasoupErrors<T>(_ throwingClosure: () throws -> T) throw
 				if let underlyingError = error.errorUserInfo[NSUnderlyingErrorKey] as? NSError {
 					throw MediasoupError.mediasoup(underlyingError)
 				} else {
-                    throw MediasoupError.unknown(description(error))
+                    			throw MediasoupError.unknown(description(error))
 				}
 			@unknown default:
 				throw MediasoupError.unknown(description(error))
 		}
 	} catch {
-        throw MediasoupError.unknown(error.localizedDescription)
+        	throw MediasoupError.unknown(error.localizedDescription)
 	}
 }

--- a/Mediasoup/MediasoupClientErrorConverter.swift
+++ b/Mediasoup/MediasoupClientErrorConverter.swift
@@ -22,12 +22,12 @@ internal func convertMediasoupErrors<T>(_ throwingClosure: () throws -> T) throw
 				if let underlyingError = error.errorUserInfo[NSUnderlyingErrorKey] as? NSError {
 					throw MediasoupError.mediasoup(underlyingError)
 				} else {
-					throw MediasoupError.unknown(error)
+                    throw MediasoupError.unknown(description(error))
 				}
 			@unknown default:
-				throw MediasoupError.unknown(error)
+				throw MediasoupError.unknown(description(error))
 		}
 	} catch {
-		throw MediasoupError.unknown(error)
+        throw MediasoupError.unknown(error.localizedDescription)
 	}
 }

--- a/Mediasoup/MediasoupError.swift
+++ b/Mediasoup/MediasoupError.swift
@@ -1,10 +1,25 @@
 import Foundation
 
 
-public enum MediasoupError: Error {
+public enum MediasoupError: LocalizedError {
 	case unsupported(String)
 	case invalidState(String)
 	case invalidParameters(String)
 	case mediasoup(NSError)
-	case unknown(Error)
+    case unknown(String)
+    
+    public var errorDescription: String? {
+        switch self {
+        case .unsupported(let message):
+            return "Unsupported: \(message)"
+        case .invalidState(let message):
+            return "Invalid State: \(message)"
+        case .invalidParameters(let message):
+            return "Invalid Parameters: \(message)"
+        case .mediasoup(let error):
+            return error.localizedDescription
+        case .unknown(let message):
+            return message
+        }
+    }
 }

--- a/Mediasoup/MediasoupError.swift
+++ b/Mediasoup/MediasoupError.swift
@@ -6,20 +6,20 @@ public enum MediasoupError: LocalizedError {
 	case invalidState(String)
 	case invalidParameters(String)
 	case mediasoup(NSError)
-    case unknown(String)
+        case unknown(String)
     
-    public var errorDescription: String? {
-        switch self {
-        case .unsupported(let message):
-            return "Unsupported: \(message)"
-        case .invalidState(let message):
-            return "Invalid State: \(message)"
-        case .invalidParameters(let message):
-            return "Invalid Parameters: \(message)"
-        case .mediasoup(let error):
-            return error.localizedDescription
-        case .unknown(let message):
-            return message
+        public var errorDescription: String? {
+            switch self {
+            case .unsupported(let message):
+                return "Unsupported: \(message)"
+            case .invalidState(let message):
+                return "Invalid State: \(message)"
+            case .invalidParameters(let message):
+                return "Invalid Parameters: \(message)"
+            case .mediasoup(let error):
+                return error.localizedDescription
+            case .unknown(let message):
+                return message
+            }
         }
-    }
 }


### PR DESCRIPTION
## Problem
When catching MediasoupError, the error description was not properly accessible through `localizedDescription`, resulting in generic error messages like "MediasoupError error 4" instead of the actual detailed error description.

## Solution
Added `LocalizedError` protocol conformance to `MediasoupError` to properly expose the underlying error descriptions. This makes error messages more descriptive and helpful for debugging.

## Changes
- Made `MediasoupError` conform to `LocalizedError`
- Implemented `errorDescription` property to provide detailed error messages
- Error messages now include the full context of the underlying error

## Example
Before:
```
catch error {
print(error.localizedDescription)
// Prints: "MediasoupError error 4"
}
```
After:
```
catch error {
print(error.localizedDescription)
// Prints: "Unknown error: [json.exception.parse_error.101] parse error at line 1..."
}

```
This change helps developers better understand and debug issues.